### PR TITLE
Add Vercel configuration for client build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/public",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel config to serve the built client from `dist/public`

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890282652b08324bb338daa72d52403