### PR TITLE
feat: add fallback product fetch

### DIFF
--- a/client/src/pages/ProductFeed.tsx
+++ b/client/src/pages/ProductFeed.tsx
@@ -90,8 +90,15 @@ export default function ProductFeed() {
         console.log('Products fetched successfully:', data.products?.length || data.length, 'products');
         return data;
       } catch (err) {
-        console.error('Error fetching products:', err);
-        throw err;
+        console.warn('Primary products endpoint failed, attempting fallback:', err);
+        const fallbackRes = await fetch('/api/products');
+        if (!fallbackRes.ok) {
+          console.error('Fallback products API error:', fallbackRes.status, fallbackRes.statusText);
+          throw err;
+        }
+        const fallbackData = await fallbackRes.json();
+        console.log('Fallback products fetched:', fallbackData.length, 'products');
+        return { products: fallbackData };
       }
     },
     staleTime: 30 * 1000, // 30 seconds


### PR DESCRIPTION
## Summary
- ensure product feed falls back to basic products endpoint when vendor detail endpoint fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890585406ec8324a79ba7577b61b2b5